### PR TITLE
feat: comment out registry tab, show only install tab

### DIFF
--- a/src/components/quickstart-card.tsx
+++ b/src/components/quickstart-card.tsx
@@ -7,12 +7,12 @@ import { CopyIcon } from "@/components/icons/copy";
 import { MoonIcon } from "@/components/icons/moon";
 import { ThemeSwitcherElement } from "@/components/theme-switcher-element";
 import { Button } from "@/components/ui/button";
-import {
-  Carousel,
-  type CarouselApi,
-  CarouselContent,
-  CarouselItem,
-} from "@/components/ui/carousel";
+// import {
+//   Carousel,
+//   type CarouselApi,
+//   CarouselContent,
+//   CarouselItem,
+// } from "@/components/ui/carousel";
 import { CodeBlock } from "@/components/ui/code-block";
 
 interface QuickstartCardProps {
@@ -20,24 +20,21 @@ interface QuickstartCardProps {
 }
 
 export function QuickstartCard({ className = "" }: QuickstartCardProps) {
-  const [activeTab, setActiveTab] = useState<"registry" | "install">(
-    "registry",
-  );
-  const [copied, setCopied] = useState<"registry" | "install" | null>(null);
-  const [api, setApi] = useState<CarouselApi>();
+  // const [activeTab, setActiveTab] = useState<"registry" | "install">(
+  //   "registry",
+  // );
+  const [copied, setCopied] = useState<"install" | null>(null);
+  // const [api, setApi] = useState<CarouselApi>();
 
-  const registryCode = `{
-  "registries": {
-    "@elements": "https://tryelements.dev/r/{name}.json"
-  }
-}`;
+  // const registryCode = `{
+  // "registries": {
+  //   "@elements": "https://tryelements.dev/r/{name}.json"
+  // }
+  // }`;
 
   const installCode = `bunx shadcn add @elements/theme-switcher`;
 
-  const copyToClipboard = async (
-    text: string,
-    type: "registry" | "install",
-  ) => {
+  const copyToClipboard = async (text: string, type: "install") => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(type);
@@ -47,31 +44,31 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
     }
   };
 
-  const registryMicrocopy = "Add the Elements registry once";
+  // const registryMicrocopy = "Add the Elements registry once";
 
   // Handle tab clicks - control carousel
-  const handleTabClick = (tab: "registry" | "install") => {
-    setActiveTab(tab);
-    if (api) {
-      const index = tab === "registry" ? 0 : 1;
-      api.scrollTo(index);
-    }
-  };
+  // const handleTabClick = (tab: "registry" | "install") => {
+  //   setActiveTab(tab);
+  //   if (api) {
+  //     const index = tab === "registry" ? 0 : 1;
+  //     api.scrollTo(index);
+  //   }
+  // };
 
   // Listen to carousel changes
-  useEffect(() => {
-    if (!api) return;
+  // useEffect(() => {
+  //   if (!api) return;
 
-    const onSelect = () => {
-      const index = api.selectedScrollSnap();
-      setActiveTab(index === 0 ? "registry" : "install");
-    };
+  //   const onSelect = () => {
+  //     const index = api.selectedScrollSnap();
+  //     setActiveTab(index === 0 ? "registry" : "install");
+  //   };
 
-    api.on("select", onSelect);
-    return () => {
-      api.off("select", onSelect);
-    };
-  }, [api]);
+  //   api.on("select", onSelect);
+  //   return () => {
+  //     api.off("select", onSelect);
+  //   };
+  // }, [api]);
 
   const scrollToSuggest = () => {
     const gallerySection = document.getElementById("suggest");
@@ -116,7 +113,7 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
             </div>
 
             {/* Tabs */}
-            <div className="flex gap-8 mb-4">
+            {/* <div className="flex gap-8 mb-4">
               <button
                 type="button"
                 onClick={() => handleTabClick("registry")}
@@ -139,12 +136,17 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
               >
                 Install
               </button>
+            </div> */}
+            <div className="flex gap-8 mb-4">
+              <div className="text-sm uppercase tracking-wider font-medium text-foreground border-b-2 border-primary pb-1">
+                Install
+              </div>
             </div>
           </div>
 
-          {/* Carousel with fixed height */}
+          {/* Install Panel - direct content without carousel */}
           <div className="h-[200px]">
-            <Carousel
+            {/* <Carousel
               setApi={setApi}
               opts={{
                 align: "start",
@@ -155,7 +157,7 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
             >
               <CarouselContent className="h-full">
                 {/* Registry Panel */}
-                <CarouselItem className="h-full">
+            {/* <CarouselItem className="h-full">
                   <div className="relative group h-full">
                     <CodeBlock
                       code={registryCode}
@@ -189,65 +191,59 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
                     </Button>
 
                     {/* Registry bottom content */}
-                    <p className="text-xs text-muted-foreground/70 mt-3 font-mono">
+            {/* <p className="text-xs text-muted-foreground/70 mt-3 font-mono">
                       {registryMicrocopy}
                     </p>
                   </div>
-                </CarouselItem>
+                </CarouselItem> */}
 
-                {/* Install Panel */}
-                <CarouselItem className="h-full">
-                  <div className="relative group h-full">
-                    <CodeBlock
-                      code={installCode}
-                      lang="bash"
-                      className="relative"
+            {/* Install Panel */}
+            {/* <CarouselItem className="h-full"> */}
+            <div className="relative group h-full">
+              <CodeBlock code={installCode} lang="bash" className="relative" />
+              <Button
+                onClick={() => copyToClipboard(installCode, "install")}
+                size="sm"
+                variant="outline"
+                className="absolute top-3 right-3 h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 border-border/50 hover:border-foreground/20 bg-background/80 "
+              >
+                {copied === "install" ? (
+                  <svg
+                    width="16"
+                    height="16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    className="w-4 h-4 text-primary"
+                  >
+                    <title>Copy Icon</title>
+                    <path
+                      d="M18 6h2v2h-2V6zm-2 4V8h2v2h-2zm-2 2v-2h2v2h-2zm-2 2h2v-2h-2v2zm-2 2h2v-2h-2v2zm-2 0v2h2v-2H8zm-2-2h2v2H6v-2zm0 0H4v-2h2v2z"
+                      fill="currentColor"
                     />
-                    <Button
-                      onClick={() => copyToClipboard(installCode, "install")}
-                      size="sm"
-                      variant="outline"
-                      className="absolute top-3 right-3 h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 border-border/50 hover:border-foreground/20 bg-background/80 "
-                    >
-                      {copied === "install" ? (
-                        <svg
-                          width="16"
-                          height="16"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 24 24"
-                          className="w-4 h-4 text-primary"
-                        >
-                          <title>Copy Icon</title>
-                          <path
-                            d="M18 6h2v2h-2V6zm-2 4V8h2v2h-2zm-2 2v-2h2v2h-2zm-2 2h2v-2h-2v2zm-2 2h2v-2h-2v2zm-2 0v2h2v-2H8zm-2-2h2v2H6v-2zm0 0H4v-2h2v2z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      ) : (
-                        <CopyIcon className="w-4 h-4" />
-                      )}
-                    </Button>
+                  </svg>
+                ) : (
+                  <CopyIcon className="w-4 h-4" />
+                )}
+              </Button>
 
-                    {/* Install bottom content with demo */}
-                    <div className="mt-4">
-                      <div className="flex items-center justify-center py-4 border-t border-border/30">
-                        <div className="text-center space-y-2">
-                          <ElementWrapper
-                            icon={<MoonIcon className="w-4 h-4" />}
-                          >
-                            <ThemeSwitcherElement />
-                          </ElementWrapper>
-                          <p className="text-xs text-muted-foreground/70 font-mono">
-                            next-themes • system detection • instant switching
-                          </p>
-                        </div>
-                      </div>
-                    </div>
+              {/* Install bottom content with demo */}
+              <div className="mt-4">
+                <div className="flex items-center justify-center py-4 border-t border-border/30">
+                  <div className="text-center space-y-2">
+                    <ElementWrapper icon={<MoonIcon className="w-4 h-4" />}>
+                      <ThemeSwitcherElement />
+                    </ElementWrapper>
+                    <p className="text-xs text-muted-foreground/70 font-mono">
+                      next-themes • system detection • instant switching
+                    </p>
                   </div>
-                </CarouselItem>
+                </div>
+              </div>
+            </div>
+            {/* </CarouselItem>
               </CarouselContent>
-            </Carousel>
+            </Carousel> */}
           </div>
 
           {/* CTAs */}
@@ -255,14 +251,9 @@ export function QuickstartCard({ className = "" }: QuickstartCardProps) {
             <Button
               size="sm"
               className="text-xs font-medium"
-              onClick={() =>
-                copyToClipboard(
-                  activeTab === "registry" ? registryCode : installCode,
-                  activeTab,
-                )
-              }
+              onClick={() => copyToClipboard(installCode, "install")}
             >
-              {copied === activeTab ? "Copied!" : "Copy Code"}
+              {copied === "install" ? "Copied!" : "Copy Code"}
             </Button>
             <Button
               size="sm"


### PR DESCRIPTION
- Remove registry tab from quickstart card since we're officially in shadcn registry
- Simplify component to show only the install command: bunx shadcn add @elements/theme-switcher
- Keep registry code commented for future reference
<img width="1208" height="549" alt="image" src="https://github.com/user-attachments/assets/b1bba048-bb5e-4bad-a1f4-1a18aafbd67f" />
